### PR TITLE
hollowdb v1.2.0 --> v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "helmet": "^6.1.5",
-    "hollowdb": "^1.2.0",
+    "hollowdb": "^1.2.1",
     "http-status-codes": "^2.2.0",
     "joi": "^17.9.2",
     "warp-contracts": "^1.4.5",

--- a/src/clients/bundlr.ts
+++ b/src/clients/bundlr.ts
@@ -12,10 +12,9 @@ class BundlrClient implements Client {
     this.bundlr = new Bundlr('http://node1.bundlr.network', 'arweave', jwk);
   }
 
-  //download the cache and setVerkey and whiteLists if needed
+  // todo
   public async setup(): Promise<void> {}
-
-  //TODO: delete cache
+  // todo
   public async destroy(): Promise<void> {}
 
   public static getInstance(): BundlrClient {

--- a/src/controllers/hollow.controller.ts
+++ b/src/controllers/hollow.controller.ts
@@ -9,8 +9,6 @@ import type {
   IUpdateBody,
 } from '../interfaces/hollow.interface';
 
-// TODO: remove "as string" castings
-
 export async function put(
   request: Request<{}, {}, IPutBody>,
   response: Response
@@ -19,8 +17,7 @@ export async function put(
   console.log('PUTTING:', typeof value);
 
   try {
-    // TODO: if value is not a string, make it via JSON.stringify()
-    await hollowClient().hollowdb.put(key, value as string);
+    await hollowClient().hollowdb.put(key, value);
     return respond.success(response, 'success', {}, StatusCodes.OK);
   } catch (err) {
     const error = err as Error;
@@ -37,7 +34,7 @@ export async function update(
 ) {
   const {key, value, proof} = request.body;
   try {
-    await hollowClient().hollowdb.update(key, value as string, proof);
+    await hollowClient().hollowdb.update(key, value, proof);
     return respond.success(response, 'success', {}, StatusCodes.OK);
   } catch (err) {
     const error = err as Error;

--- a/src/interfaces/hollow.interface.ts
+++ b/src/interfaces/hollow.interface.ts
@@ -2,12 +2,12 @@ import {} from 'express';
 
 export interface IPutBody {
   key: string;
-  value: string | object;
+  value: unknown;
 }
 
 export interface IUpdateBody {
   key: string;
-  value: string | object;
+  value: unknown;
   proof: object | undefined;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -648,6 +648,11 @@
     fastfile "0.0.20"
     ffjavascript "^0.2.48"
 
+"@ioredis/commands@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
+  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -1575,7 +1580,7 @@
   dependencies:
     "@randlabs/communication-bridge" "1.0.1"
 
-"@redis/client@^1.5.6", "@redis/client@^1.5.7":
+"@redis/client@^1.5.7":
   version "1.5.7"
   resolved "https://registry.yarnpkg.com/@redis/client/-/client-1.5.7.tgz#92cc5c98c76f189e37d24f0e1e17e104c6af17d4"
   integrity sha512-gaOBOuJPjK5fGtxSseaKgSvjiZXQCdLlGg9WYQst+/GRUjmXaiB5kVkeQMRtPc7Q2t93XZcJfBMSwzs/XS9UZw==
@@ -3217,7 +3222,7 @@ clui@^0.3.6:
   dependencies:
     cli-color "0.3.2"
 
-cluster-key-slot@1.1.2:
+cluster-key-slot@1.1.2, cluster-key-slot@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
   integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
@@ -3520,7 +3525,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.3.4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
+debug@4, debug@4.3.4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -3598,6 +3603,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
+
+denque@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
@@ -4685,20 +4695,21 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hollowdb@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hollowdb/-/hollowdb-1.2.0.tgz#947a28a6c4125f240d5e19069ff90de473d5b116"
-  integrity sha512-1XJ9bllaYlXyuLWI2u16bxH7IsYcNyS0RjOcwQd9/Ze3o841BmXM0nzjDOpOZOfIwCv2+Ye8xZsVKtapd5WCFg==
+hollowdb@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/hollowdb/-/hollowdb-1.2.1.tgz#46b51a5df8f196e9363dcf96428ede785267968b"
+  integrity sha512-QNp7xx7woEEqG9Z36PRWHEl688x2t4HFt9+JQTfIbaDBUp+Gy8fwhK30sTwXPLudispyGx1yvmtLuSFhACxf9Q==
   dependencies:
     warp-contracts "^1.4.2"
     warp-contracts-plugin-deploy "^1.0.7"
     warp-contracts-plugin-ethers "^1.0.7"
     warp-contracts-plugin-snarkjs "^0.1.6"
   optionalDependencies:
-    "@redis/client" "^1.5.6"
+    ioredis "^5.3.2"
+    poseidon-lite "^0.1.0"
     snarkjs "^0.6.1"
     warp-contracts-lmdb "^1.1.10"
-    warp-contracts-redis "^0.1.3"
+    warp-contracts-redis "^0.2.0"
 
 hoopy@^0.1.4:
   version "0.1.4"
@@ -4919,6 +4930,21 @@ interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
+
+ioredis@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.3.2.tgz#9139f596f62fc9c72d873353ac5395bcf05709f7"
+  integrity sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==
+  dependencies:
+    "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
 
 ip@^2.0.0:
   version "2.0.0"
@@ -5451,6 +5477,11 @@ lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.isequal@^4.5.0:
   version "4.5.0"
@@ -6462,6 +6493,11 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
+poseidon-lite@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/poseidon-lite/-/poseidon-lite-0.1.1.tgz#368b040cd4cc0232a4cb288146b13a8536cdbc9f"
+  integrity sha512-Fb5tEeg+X1/W3Vm7Jb03Lg3rQHyhzQ3mtPId/V5CuBIqB7dbO+A0k1sLro/e8KvEJV+eLyiRLVdEEexNT6ZTeA==
+
 poseidon-lite@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/poseidon-lite/-/poseidon-lite-0.2.0.tgz#dbc242ebd9c10c32d507a533fa497231d168fd72"
@@ -6725,6 +6761,18 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
+  dependencies:
+    redis-errors "^1.0.0"
+
 regenerator-runtime@^0.13.11:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
@@ -6874,6 +6922,11 @@ safe-stable-stringify@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz#34694bd8a30575b7f94792aa51527551bd733d61"
   integrity sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==
+
+safe-stable-stringify@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
+  integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.1.0:
   version "2.1.2"
@@ -7149,6 +7202,11 @@ ssri@^8.0.0, ssri@^8.0.1:
   integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
   dependencies:
     minipass "^3.1.1"
+
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 statuses@2.0.1:
   version "2.0.1"
@@ -7742,12 +7800,13 @@ warp-contracts-plugin-snarkjs@^0.1.6:
   dependencies:
     snarkjs "^0.6.10"
 
-warp-contracts-redis@^0.1.3:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/warp-contracts-redis/-/warp-contracts-redis-0.1.5.tgz#bed828a3011b40d950fdb7335906dc89bfc21b8a"
-  integrity sha512-87C8FbRSdka0nGzr0HKh7j2gOdqTJXvIgtZWw/UTsgFbHcQ5RmTyT4DXtRKRv258Wm3eGUbCUZKDA95TYAm1ag==
+warp-contracts-redis@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/warp-contracts-redis/-/warp-contracts-redis-0.2.1.tgz#380126c8d2faa57068a88d7600ad3c48953b64ae"
+  integrity sha512-9oZakfyvUtAb3GevkZOrcvs5/C5MMlkeQ1Dp5kn3hA70Nw4dUwTfIAXwrqQcyRYRbWXlLaOoYUSuh/9wt7aaIQ==
   dependencies:
-    "@redis/client" "^1.5.6"
+    ioredis "^5.3.2"
+    safe-stable-stringify "^2.4.3"
     warp-contracts "^1.4.2"
 
 warp-contracts@^1.4.2, warp-contracts@^1.4.5:


### PR DESCRIPTION
Removed `as string` annotations.